### PR TITLE
Implement pod lookup in wrestic

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,6 +12,7 @@
         "program": "${workspaceFolder}/cmd/wrestic/main.go",
         "port": 2345,
         "host": "127.0.0.1",
+        "showGlobalVariables": false,
         "env": {
             "RESTIC_REPOSITORY": "s3:http://localhost:9000/baas1",
             "RESTIC_PASSWORD": "asdf",
@@ -21,6 +22,7 @@
             "HOSTNAME":"test",
             "BACKUP_DIR": "/Users/simonbeck/Desktop/data",
             "STATS_URL": "http://localhost:8091",
+            "NAMESPACE": "myproject",
         }
       },
       {
@@ -53,13 +55,13 @@
         "args": [
             "-stdin",
             "-arrayOpts",
-            "/bin/bash -c 'mysqldump --all-databases -h$MARIADB_HOST -u$MARIADB_USERNAME -p$MARIADB_PASSWORD',cli-41-84ffx,cli,govcms-site-master",
+            "/bin/bash -c 'mysqldump -uroot -psecure --all-databases',mariadb-77bf4956b9-klkt7,mariadb,myproject",
         ],
         "port": 2345,
         "host": "127.0.0.1",
         "env": {
-            "RESTIC_REPOSITORY": "s3:http://10.144.1.133:9000/baas1",
-            "RESTIC_PASSWORD": "asdf",
+            "RESTIC_REPOSITORY": "s3:http://localhost:9000/baas",
+            "RESTIC_PASSWORD": "password",
             "AWS_ACCESS_KEY_ID": "8U0UDNYPNUDTUS1LIAF3",
             "AWS_SECRET_ACCESS_KEY": "ip3cdrkXcHmH4S7if7erKPNoxDn27V0vrg6CHHem",
             "PROM_URL":"http://localhost:9091/",
@@ -103,10 +105,12 @@
             "-restore",
             "-restoreType",
             "s3",
+            "-restoreSnap",
+            "7a24ca037aa01b9ceaf3d4be189dddb2ecfedf603217970a8f2027609797f4b1",
         ],
         "env": {
-            "RESTIC_REPOSITORY": "s3:http://localhost:9000/baas1",
-            "RESTIC_PASSWORD": "asdf",
+            "RESTIC_REPOSITORY": "s3:http://localhost:9000/baas",
+            "RESTIC_PASSWORD": "password",
             "AWS_ACCESS_KEY_ID": "8U0UDNYPNUDTUS1LIAF3",
             "AWS_SECRET_ACCESS_KEY": "ip3cdrkXcHmH4S7if7erKPNoxDn27V0vrg6CHHem",
             "PROM_URL":"http://localhost:9091/",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -36,6 +36,7 @@
           ],
           "port": 2345,
           "host": "127.0.0.1",
+          "showGlobalVariables": false,
           "env": {
               "RESTIC_REPOSITORY": "s3:http://10.144.1.133:9000/baas1",
               "RESTIC_PASSWORD": "asdf",
@@ -46,29 +47,6 @@
               "BACKUP_DIR": "/Users/simonbeck/Desktop/data",
           }
       },
-      {
-        "name": "Launch restic stdin",
-        "type": "go",
-        "request": "launch",
-        "mode": "debug",
-        "program": "${workspaceFolder}/cmd/wrestic/main.go",
-        "args": [
-            "-stdin",
-            "-arrayOpts",
-            "/bin/bash -c 'mysqldump -uroot -psecure --all-databases',mariadb-77bf4956b9-klkt7,mariadb,myproject",
-        ],
-        "port": 2345,
-        "host": "127.0.0.1",
-        "env": {
-            "RESTIC_REPOSITORY": "s3:http://localhost:9000/baas",
-            "RESTIC_PASSWORD": "password",
-            "AWS_ACCESS_KEY_ID": "8U0UDNYPNUDTUS1LIAF3",
-            "AWS_SECRET_ACCESS_KEY": "ip3cdrkXcHmH4S7if7erKPNoxDn27V0vrg6CHHem",
-            "PROM_URL":"http://localhost:9091/",
-            "HOSTNAME":"test",
-            "BACKUP_DIR": "/Users/simonbeck/Desktop/data",
-        }
-    },
     {
         "name": "Launch restic restore folder",
         "type": "go",
@@ -76,6 +54,7 @@
         "mode": "debug",
         "program": "${workspaceFolder}/cmd/wrestic/main.go",
         "port": 2345,
+        "showGlobalVariables": false,
         "host": "127.0.0.1",
         "args":[
             "-restore",
@@ -98,6 +77,7 @@
         "type": "go",
         "request": "launch",
         "mode": "debug",
+        "showGlobalVariables": false,
         "program": "${workspaceFolder}/cmd/wrestic/main.go",
         "port": 2345,
         "host": "127.0.0.1",
@@ -127,6 +107,7 @@
         "type": "go",
         "request": "launch",
         "mode": "debug",
+        "showGlobalVariables": false,
         "program": "${workspaceFolder}/cmd/wrestic/main.go",
         "port": 2345,
         "host": "127.0.0.1",
@@ -154,6 +135,7 @@
         "type": "go",
         "request": "launch",
         "mode": "debug",
+        "showGlobalVariables": false,
         "program": "${workspaceFolder}/cmd/wrestic/main.go",
         "port": 2345,
         "host": "127.0.0.1",

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /tmp
 #     mkdir /.cache && chmod -R 777 /.cache
 
 RUN set -x; apk add --no-cache wget bzip2 ca-certificates git gcc && \
-    git clone https://github.com/Kidswiss/restic && cd restic \
+    git clone https://github.com/Kidswiss/restic && cd restic && \
     git checkout tar && go run -mod=vendor build.go -v && \
     mv restic /usr/local/bin/restic && chmod +x /usr/local/bin/restic && \
     mkdir /.cache && chmod -R 777 /.cache

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ All the configuration needed can be done via environment variables:
 * `RESTORE_S3ENDPOINT` s3 endpoint where the tar.gz with all files should be uploaded, example `http://localhost:9000/bucketName`
 * `RESTORE_ACCESSKEYID` s3 accesKeyID for the restore s3 endpoint
 * `RESTORE_SECRETACCESSKEY` s3 secretAccessKey for the restore s3 endpoint
+* `BACKUPCOMMAND_ANNOTATION` name of the backup command annotation, default: `appuio.ch/backupcommand`
+* `FILEEXTENSION_ANNOTATION` name of the file extension annotation, default: `backup.appuio.ch/file-extension`
 
 Configuration for the Restic repository also has to be provided via env variables. See the official [docs](https://restic.readthedocs.io/en/latest/).
 

--- a/cmd/wrestic/main.go
+++ b/cmd/wrestic/main.go
@@ -95,12 +95,17 @@ func run(finishC chan error, outputManager *output.Output) {
 	resticCli.InitRepository(s3BackupClient)
 
 	if resticCli.Initrepo.GetError() != nil {
-		finishC <- fmt.Errorf("error contacting the repository: %v\n", resticCli.Initrepo.GetError())
+		finishC <- fmt.Errorf("error contacting the repository: %v", resticCli.Initrepo.GetError())
+		return
 	}
 
 	var criticalError error
 
 	resticCli.Unlock(false)
+	if resticCli.UnlockStruct.GetError() != nil {
+		finishC <- fmt.Errorf("could not unlock repository: %v", resticCli.UnlockStruct.GetError())
+		return
+	}
 	defer resticCli.Unlock(false)
 
 	if *prune {

--- a/kubernetes/config.go
+++ b/kubernetes/config.go
@@ -1,0 +1,40 @@
+package kubernetes
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func getClientConfig() (*rest.Config, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		err1 := err
+		kubeconfig := filepath.Join(os.Getenv("HOME"), ".kube", "config")
+		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+		if err != nil {
+			err = fmt.Errorf("InClusterConfig as well as BuildConfigFromFlags Failed. Error in InClusterConfig: %+v\nError in BuildConfigFromFlags: %+v", err1, err)
+			return nil, err
+		}
+	}
+
+	return config, nil
+}
+
+func newk8sClient() (*kubernetes.Clientset, error) {
+	config, err := getClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	k8sclient, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		fmt.Println(err)
+		return nil, err
+	}
+
+	return k8sclient, nil
+}

--- a/kubernetes/podExec.go
+++ b/kubernetes/podExec.go
@@ -4,16 +4,12 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"firepear.net/qsplit"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/remotecommand"
 )
 
@@ -86,19 +82,4 @@ func PodExec(params Params) (io.Reader, *bytes.Buffer, error) {
 	}()
 
 	return stdoutReader, &stderr, nil
-}
-
-func getClientConfig() (*rest.Config, error) {
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		err1 := err
-		kubeconfig := filepath.Join(os.Getenv("HOME"), ".kube", "config")
-		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
-		if err != nil {
-			err = fmt.Errorf("InClusterConfig as well as BuildConfigFromFlags Failed. Error in InClusterConfig: %+v\nError in BuildConfigFromFlags: %+v", err1, err)
-			return nil, err
-		}
-	}
-
-	return config, nil
 }

--- a/kubernetes/podList.go
+++ b/kubernetes/podList.go
@@ -1,0 +1,84 @@
+package kubernetes
+
+import (
+	"fmt"
+
+	kube "k8s.io/client-go/kubernetes"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// PodLister holds the state for listing the pods.
+type PodLister struct {
+	backupCommandAnnotation string
+	fileExtensionAnnotation string
+	k8scli                  *kube.Clientset
+	err                     error
+	namespace               string
+}
+
+// BackupPod contains all information nessecary to execute the backupcommands.
+type BackupPod struct {
+	Command       string
+	PodName       string
+	ContainerName string
+	Namespace     string
+	FileExtension string
+}
+
+// NewPodLister returns a PodLister configured to find the defined annotations.
+func NewPodLister(backupCommandAnnotation, fileExtensionAnnotation, namespace string) *PodLister {
+	k8cli, err := newk8sClient()
+	return &PodLister{
+		backupCommandAnnotation: backupCommandAnnotation,
+		fileExtensionAnnotation: fileExtensionAnnotation,
+		k8scli:                  k8cli,
+		err:                     err,
+		namespace:               namespace,
+	}
+}
+
+// ListPods resturns a list of pods which have backup commands in their annotations.
+func (p *PodLister) ListPods() ([]BackupPod, error) {
+	fmt.Printf("Listing all pods with annotation %v in namespace %v\n", p.backupCommandAnnotation, p.namespace)
+
+	pods, err := p.k8scli.CoreV1().Pods(p.namespace).List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	foundPods := []BackupPod{}
+
+	sameOwner := make(map[string]bool)
+
+	for _, pod := range pods.Items {
+		if pod.Status.Phase != corev1.PodRunning {
+			continue
+		}
+		annotations := pod.GetAnnotations()
+
+		if command, ok := annotations[p.backupCommandAnnotation]; ok {
+
+			fileExtension := annotations[p.fileExtensionAnnotation]
+
+			owner := pod.OwnerReferences
+			firstOwnerID := string(owner[0].UID)
+
+			if _, ok := sameOwner[firstOwnerID]; !ok {
+				sameOwner[firstOwnerID] = true
+				fmt.Printf("Adding %v/%v to backuplist\n", p.namespace, pod.Name)
+				foundPods = append(foundPods, BackupPod{
+					Command:       command,
+					PodName:       pod.Name,
+					ContainerName: pod.Spec.Containers[0].Name,
+					Namespace:     p.namespace,
+					FileExtension: fileExtension,
+				})
+			}
+
+		}
+	}
+
+	return foundPods, nil
+}

--- a/restic/restic.go
+++ b/restic/restic.go
@@ -25,6 +25,7 @@ const (
 	BackupDirEnv   = "BACKUP_DIR"
 	restoreDirEnv  = "RESTORE_DIR"
 	listTimeoutEnv = "BACKUP_LIST_TIMEOUT"
+	repositoryEnv  = "RESTIC_REPOSITORY"
 	//Arguments for restic
 	keepLastArg    = "--keep-last"
 	keepHourlyArg  = "--keep-hourly"

--- a/restic/restore.go
+++ b/restic/restore.go
@@ -260,6 +260,7 @@ func (r *RestoreStruct) getTarReader(snapshot Snapshot) tarStream {
 
 			stdOut, err := cmd.StdoutPipe()
 			if err != nil {
+				r.errorMessage = err
 				return
 			}
 			var stdErr bytes.Buffer
@@ -268,6 +269,7 @@ func (r *RestoreStruct) getTarReader(snapshot Snapshot) tarStream {
 			err = cmd.Start()
 			if err != nil {
 				fmt.Println(err)
+				r.errorMessage = err
 				return
 			}
 
@@ -278,6 +280,7 @@ func (r *RestoreStruct) getTarReader(snapshot Snapshot) tarStream {
 			if err != nil {
 				fmt.Printf("Command failed with: '%v'\n", err)
 				fmt.Printf("Output: %v\n", stdErr.String())
+				r.errorMessage = err
 				return
 			}
 		},

--- a/s3/client.go
+++ b/s3/client.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/minio/minio-go"
+	minio "github.com/minio/minio-go"
 )
 
 // Client wraps the minio s3 client
@@ -60,7 +60,7 @@ func (c *Client) Connect() error {
 
 func (c *Client) createBucket() error {
 	exists, err := c.minioClient.BucketExists(c.bucket)
-	if !exists && err == nil {
+	if !exists && (err == nil || strings.Contains(err.Error(), "exist")) {
 		return c.minioClient.MakeBucket(c.bucket, "")
 	} else if err != nil {
 		return err


### PR DESCRIPTION
With this commit the pod lookup will move to the wrestic container. The lookup will not trigger a critical error, if no namespace was provided. This will also need changes in the k8up operator as it passes the namespace to wrestic.
