### PR TITLE
Use Restic 0.9.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,15 @@
-FROM golang:1.11-alpine
+FROM golang:1.12-alpine
 
-ENV RESTIC_VERSION=0.9.3 \
-    SHASUM=3c882962fc07f611a6147ada99c9909770d3e519210fd483cde9609c6bdd900c
+ENV RESTIC_VERSION=0.9.5 \
+    SHASUM=08cd75e56a67161e9b16885816f04b2bf1fb5b03bc0677b0ccf3812781c1a2ec
 
 WORKDIR /tmp
-# TODO: re-enable this when APPU-1524 is done
-# RUN set -x; apk add --no-cache wget bzip2 ca-certificates && \
-#     wget -q -O restic.bz2 https://github.com/restic/restic/releases/download/v${RESTIC_VERSION}/restic_${RESTIC_VERSION}_linux_amd64.bz2 && \
-#     echo "${SHASUM}  restic.bz2" | sha256sum -c - && \
-#     bzip2 -d restic.bz2 && \
-#     mv restic /usr/local/bin/restic && \
-#     chmod +x /usr/local/bin/restic && \
-#     mkdir /.cache && chmod -R 777 /.cache
-
-RUN set -x; apk add --no-cache wget bzip2 ca-certificates git gcc && \
-    git clone https://github.com/Kidswiss/restic && cd restic && \
-    git checkout tar && go run -mod=vendor build.go -v && \
-    mv restic /usr/local/bin/restic && chmod +x /usr/local/bin/restic && \
+RUN set -x; apk add --no-cache wget bzip2 ca-certificates && \
+    wget -q -O restic.bz2 https://github.com/restic/restic/releases/download/v${RESTIC_VERSION}/restic_${RESTIC_VERSION}_linux_amd64.bz2 && \
+    echo "${SHASUM}  restic.bz2" | sha256sum -c - && \
+    bzip2 -d restic.bz2 && \
+    mv restic /usr/local/bin/restic && \
+    chmod +x /usr/local/bin/restic && \
     mkdir /.cache && chmod -R 777 /.cache
 
 WORKDIR /go/src/git.vshn.net/vshn/wrestic

--- a/restic/listsnapshots.go
+++ b/restic/listsnapshots.go
@@ -9,7 +9,7 @@ import (
 	"git.vshn.net/vshn/wrestic/output"
 )
 
-const notInitialisedError = "Not initialised yet"
+const notInitialisedError = "not initialised yet"
 
 // ListSnapshotsStruct holds the state of the listsnapshots command.
 type ListSnapshotsStruct struct {
@@ -27,10 +27,9 @@ func (l *ListSnapshotsStruct) ListSnapshots(last bool) []Snapshot {
 	if last {
 		args = append(args, "--last")
 	}
-	var timeout int
 
 	l.genericCommand.exec(args, commandOptions{print: false})
-	fmt.Printf("Listing snapshots, timeout: %v\n", timeout)
+	fmt.Printf("Listing snapshots\n")
 	if len(l.stdErrOut) > 1 && strings.Contains(l.stdErrOut[1], "following location?") {
 		l.errorMessage = errors.New(notInitialisedError)
 		return nil


### PR DESCRIPTION
With the new version of Restic two major useful features were introduced:
* JSON output for backups
* My own contribution for tar restores to stdout

Both of them improve the quality of wrestic quite a bit as we can now output almost real time stats what wrestic is doing, as well as remove anything that pointed to our own Restic fork.