### PR TITLE
Stdin output fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Webhook output now occurs after each PVC with metrics about that specific backup. The list with all the snapshots is sent after all PVCs finished. This should reduce the strain on webhook handling for very large backup sets.
 ### Fixed
 - Make the short ID usable in for the restore
+- Use Restic 0.9.5
+- Realtime backup stats in container
 
 ## [v0.0.10] - 2019-04-05
 **Attention:** This release needs a custom version of Restic with the new dump

--- a/output/output.go
+++ b/output/output.go
@@ -92,15 +92,19 @@ func (o *Output) TriggerAll() {
 
 // TriggerProm pushes a prometheus collector
 func (o *Output) TriggerProm(prom prometheus.Collector) {
-	o.prometheusPusher.Update(prom)
+	if o.prometheusPusher.url != "" {
+		o.prometheusPusher.Update(prom)
+	}
 }
 
 // TriggerHook pushes a single json
 func (o *Output) TriggerHook(data JsonMarshaller) {
-	err := o.webhookPusher.Push(data)
-	if err != nil {
-		fmt.Println(err)
-	} else {
-		fmt.Println("done")
+	if o.webhookPusher.url != "" {
+		err := o.webhookPusher.Push(data)
+		if err != nil {
+			fmt.Println(err)
+		} else {
+			fmt.Println("done")
+		}
 	}
 }

--- a/restic/backup.go
+++ b/restic/backup.go
@@ -188,7 +188,8 @@ func (b *BackupStruct) StdinBackup(backupCommand, pod, container, namespace, fil
 	parsedSummary := make(chan rawMetrics, 0)
 	go b.parse(host, parsedSummary)
 	b.genericCommand.exec(args, commandOptions{
-		print: true,
+		print:  false,
+		output: b.liveOutput,
 		Params: kubernetes.Params{
 			Pod:           pod,
 			Container:     container,

--- a/restic/genericCommand.go
+++ b/restic/genericCommand.go
@@ -22,6 +22,9 @@ type commandOptions struct {
 	print bool
 	stdin bool
 	kubernetes.Params
+	// output can be used to get realtime output from the restic command
+	// not all subcommands have realtime output though, so it's not mandatory
+	// to set it.
 	output chan string
 }
 


### PR DESCRIPTION
After introducing the changes about the log output handling there was a bug that made wrestic hang if it backed up a pod via stdin. This merge request fixes that.

Internal ticket APPU-2152