### PR TITLE
Make wrestic understand the short IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - Webhook output now occurs after each PVC with metrics about that specific backup. The list with all the snapshots is sent after all PVCs finished. This should reduce the strain on webhook handling for very large backup sets.
+### Fixed
+- Make the short ID usable in for the restore
 
 ## [v0.0.10] - 2019-04-05
 **Attention:** This release needs a custom version of Restic with the new dump

--- a/restic/restore.go
+++ b/restic/restore.go
@@ -108,8 +108,10 @@ func (r *RestoreStruct) restoreCommand(snapshotID, method string, snaps []Snapsh
 		fmt.Printf("Snapshot %v is being restored.\n", snapshot.Time)
 	} else {
 		for i := range snaps {
-			if snaps[i].ID == snapshotID {
+			// Doing substrings so we can also use short IDs here.
+			if snaps[i].ID[0:len(snapshotID)] == snapshotID {
 				snapshot = snaps[i]
+				break
 			}
 		}
 		if snapshot.ID == "" {


### PR DESCRIPTION
When using `restic snapshots` to determine what snapshot to use you previously had to print the whole JSON and get the full ID from there.

Now wrestic will substring the ID while comparing so it should always find the ID even if it's the short one the long one.

Solves internal ticket APPU-1901