### PR TITLE
Pass signals to the restic process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Webhook output now occurs after each PVC with metrics about that specific backup. The list with all the snapshots is sent after all PVCs finished. This should reduce the strain on webhook handling for very large backup sets.
 - The PVC paths in the Restic snapshot get trimmed away, so we can seamlessly restore directly to a PVC without having to copy stuff around.
-### Fixed
-- Make the short ID usable in for the restore
+- Pass signals to the restic process
 - Use Restic 0.9.5
 - Realtime backup stats in container
+### Fixed
+- Make the short ID usable in for the restore
+
 
 ## [v0.0.10] - 2019-04-05
 **Attention:** This release needs a custom version of Restic with the new dump

--- a/go.mod
+++ b/go.mod
@@ -58,3 +58,5 @@ require (
 	k8s.io/client-go v5.0.1+incompatible
 	k8s.io/kube-openapi v0.0.0-20180719232738-d8ea2fe547a4 // indirect
 )
+
+go 1.13

--- a/restic/backup.go
+++ b/restic/backup.go
@@ -125,13 +125,15 @@ func (p *promMetrics) toSlice() []prometheus.Collector {
 	}
 }
 
-func newBackup(backupDir string, listSnapshots *ListSnapshotsStruct, webhookSender WebhookSender) *BackupStruct {
+func newBackup(backupDir string, listSnapshots *ListSnapshotsStruct, webhookSender WebhookSender, commandState *commandState) *BackupStruct {
+	genericCommand := newGenericCommand(commandState)
 	return &BackupStruct{
 		backupDir:      backupDir,
 		snapshotLister: listSnapshots,
 		rawMetrics:     []rawMetrics{},
 		liveOutput:     make(chan string, 0),
 		webhookSender:  webhookSender,
+		genericCommand: *genericCommand,
 	}
 }
 

--- a/restic/check.go
+++ b/restic/check.go
@@ -9,8 +9,11 @@ type CheckStruct struct {
 	genericCommand
 }
 
-func newCheck() *CheckStruct {
-	return &CheckStruct{}
+func newCheck(commandState *commandState) *CheckStruct {
+	genericCommand := newGenericCommand(commandState)
+	return &CheckStruct{
+		genericCommand: *genericCommand,
+	}
 }
 
 // Check runs the check command.

--- a/restic/initRepository.go
+++ b/restic/initRepository.go
@@ -11,8 +11,11 @@ type Initrepo struct {
 	genericCommand
 }
 
-func newInitrepo() *Initrepo {
-	return &Initrepo{}
+func newInitrepo(commandState *commandState) *Initrepo {
+	genericCommand := newGenericCommand(commandState)
+	return &Initrepo{
+		genericCommand: *genericCommand,
+	}
 }
 
 // InitRepository checks if there's a repository and initializes it. It expects

--- a/restic/listsnapshots.go
+++ b/restic/listsnapshots.go
@@ -17,8 +17,11 @@ type ListSnapshotsStruct struct {
 	snaps snapList
 }
 
-func newListSnapshots() *ListSnapshotsStruct {
-	return &ListSnapshotsStruct{}
+func newListSnapshots(commandState *commandState) *ListSnapshotsStruct {
+	genericCommand := newGenericCommand(commandState)
+	return &ListSnapshotsStruct{
+		genericCommand: *genericCommand,
+	}
 }
 
 // ListSnapshots executes the list snapshots command of restic.

--- a/restic/prune.go
+++ b/restic/prune.go
@@ -15,10 +15,12 @@ type PruneStruct struct {
 	snapshotLister *ListSnapshotsStruct
 }
 
-func newPrune(snapshotLister *ListSnapshotsStruct, webhookSender WebhookSender) *PruneStruct {
+func newPrune(snapshotLister *ListSnapshotsStruct, webhookSender WebhookSender, commandState *commandState) *PruneStruct {
+	genericCommand := newGenericCommand(commandState)
 	return &PruneStruct{
 		webhookSender:  webhookSender,
 		snapshotLister: snapshotLister,
+		genericCommand: *genericCommand,
 	}
 }
 

--- a/restic/restore.go
+++ b/restic/restore.go
@@ -43,8 +43,11 @@ type fileNode struct {
 	StructType string    `json:"struct_type"`
 }
 
-func newRestore() *RestoreStruct {
-	return &RestoreStruct{}
+func newRestore(commandState *commandState) *RestoreStruct {
+	genericCommand := newGenericCommand(commandState)
+	return &RestoreStruct{
+		genericCommand: *genericCommand,
+	}
 }
 
 func (r *RestoreStruct) setState(restoreType, restoreDir, restoreFilter string, verifyRestore bool) {
@@ -339,7 +342,7 @@ func (r *RestoreStruct) getTarReader(snapshot Snapshot) tarStream {
 }
 
 func (r *RestoreStruct) getSnapshotRoot(snapshot Snapshot) (string, *tar.Header) {
-	cmd := newGenericCommand()
+	cmd := newGenericCommand(r.genericCommand.commandState)
 	args := []string{"ls", snapshot.ID, "--json"}
 	cmd.exec(args, commandOptions{print: false})
 	pathJSON := cmd.GetStdOut()[1]

--- a/restic/unlock.go
+++ b/restic/unlock.go
@@ -7,8 +7,11 @@ type UnlockStruct struct {
 	genericCommand
 }
 
-func newUnlock() *UnlockStruct {
-	return &UnlockStruct{}
+func newUnlock(commandState *commandState) *UnlockStruct {
+	genericCommand := newGenericCommand(commandState)
+	return &UnlockStruct{
+		genericCommand: *genericCommand,
+	}
 }
 
 // Unlock removes stale locks. A lock is stale either if the pid isn't found on


### PR DESCRIPTION
Restic can handle signals so it will cleanup properly. This further
enhances the stability when dealing with stale locks.

Internal ticket: APPU-1398