### PR TITLE
Seamless pvc restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - Webhook output now occurs after each PVC with metrics about that specific backup. The list with all the snapshots is sent after all PVCs finished. This should reduce the strain on webhook handling for very large backup sets.
+- The PVC paths in the Restic snapshot get trimmed away, so we can seamlessly restore directly to a PVC without having to copy stuff around.
 ### Fixed
 - Make the short ID usable in for the restore
 


### PR DESCRIPTION
With this commit wrestic will trim away the first two levels of the
restore path. The restore path contains "/data" + PVC name when backed
up by the k8up operator. So if restoring to the PVC "restore" it would
create this:
   
/restore/data/PVCName/**data**
    
With the trim it will cut away "/data/PVCName" and the result will be:
    
/restore/**data**
    
So the PVC is a carbon copy of the original and can be mounted and used
without any manual interventions.

Internal ticket: APPU-1897