### PR TITLE
Fix race conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Race condition with channels in the output parsing that caused wrestic to deadlock
 
 # [v0.1.6] 2019-11-14
 ### Changed

--- a/run_integration_test.go
+++ b/run_integration_test.go
@@ -58,7 +58,7 @@ func teardown(t *testing.T, f func()) {
 
 func runIntegrationTests(t *testing.T, tmpdir string) {
 	fmt.Println("=================== Starting tests ===================")
-	cmd := exec.Command("go", "test", "-v", "-mod", "vendor", "-tags", "integration", "./cmd/wrestic/...")
+	cmd := exec.Command("go", "test", "-v", "--race", "-mod", "vendor", "-tags", "integration", "./cmd/wrestic/...")
 	resticBin, _ := filepath.Abs(filepath.Join(tmpdir, "bin", "restic"))
 	fmt.Println("Restic location", resticBin)
 	cmd.Env = append(os.Environ(),


### PR DESCRIPTION
This commit fixes some race conditions I found when deploying v0.1.6 to
a prod cluster.

The most critical one was caused by a channel that wasn't closed cleanly
and re-used (b.liveOutput). Now this channel will be created for each
backup that will run from within wrestic and properly closed.