### PR TITLE
Use own restic fork with restore hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Using own restic fork with hotfix from https://github.com/restic/restic/issues/2319 in dockerbuild
 
 ### [v0.1.7] 2019-11-18
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,10 @@
 FROM docker.io/golang:1.13-alpine as build
 
-ENV RESTIC_VERSION=0.9.5 \
-    SHASUM=08cd75e56a67161e9b16885816f04b2bf1fb5b03bc0677b0ccf3812781c1a2ec
-
-WORKDIR /tmp
-RUN set -x; apk add --no-cache wget bzip2 ca-certificates && \
-    wget -q -O restic.bz2 https://github.com/restic/restic/releases/download/v${RESTIC_VERSION}/restic_${RESTIC_VERSION}_linux_amd64.bz2 && \
-    echo "${SHASUM}  restic.bz2" | sha256sum -c - && \
-    bzip2 -d restic.bz2 && \
-    mv restic /usr/local/bin/restic && \
-    chmod +x /usr/local/bin/restic && \
-    mkdir /.cache && chmod -R 777 /.cache
-
 RUN set -x; apk add --no-cache wget bzip2 ca-certificates git gcc && \
     git clone https://github.com/vshn/restic && cd restic && \
     git checkout 2319-dump-dir-tar && go run -mod=vendor build.go -v && \
-    mv restic /usr/local/bin/restic && chmod +x /usr/local/bin/restic
+    mv restic /usr/local/bin/restic && chmod +x /usr/local/bin/restic && \
+    mkdir /.cache && chmod -R 777 /.cache
 
 WORKDIR /go/src/git.vshn.net/vshn/wrestic
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.12-alpine as build
+FROM docker.io/golang:1.13-alpine as build
 
 ENV RESTIC_VERSION=0.9.5 \
     SHASUM=08cd75e56a67161e9b16885816f04b2bf1fb5b03bc0677b0ccf3812781c1a2ec
@@ -11,6 +11,11 @@ RUN set -x; apk add --no-cache wget bzip2 ca-certificates && \
     mv restic /usr/local/bin/restic && \
     chmod +x /usr/local/bin/restic && \
     mkdir /.cache && chmod -R 777 /.cache
+
+RUN set -x; apk add --no-cache wget bzip2 ca-certificates git gcc && \
+    git clone https://github.com/vshn/restic && cd restic && \
+    git checkout 2319-dump-dir-tar && go run -mod=vendor build.go -v && \
+    mv restic /usr/local/bin/restic && chmod +x /usr/local/bin/restic
 
 WORKDIR /go/src/git.vshn.net/vshn/wrestic
 COPY . .


### PR DESCRIPTION
This commit switches the build back to a custom fork of restic that
contains the fixes in following github issue:

https://github.com/restic/restic/issues/2319

The release cycles for restic are rather long and one of our customers
suffer from that issue on one of their OpenShift clusters.