### PR TITLE
Build wrestic to use root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,4 @@ RUN apk --no-cache add ca-certificates
 COPY --from=build /usr/local/bin/restic /usr/local/bin/restic
 COPY --from=build /go/bin/wrestic /app/
 
-USER 1001
-
 ENTRYPOINT [ "./wrestic" ]


### PR DESCRIPTION
This commit changes the docker build so wrestic is run as a root user
again. This should avoid any permission denied problems when backing up
PVCs.