### PR TITLE
Adding tag abilities to wrestic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Use root in docker image to avoid permission issues
 ### Added
 - Ability to pass tags to restic
+- Race condition in error parsing
 
 ## [v0.1.8] 2020-01-03
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - Use root in docker image to avoid permission issues
+### Added
+- Ability to pass tags to restic
 
 ## [v0.1.8] 2020-01-03
 ### Fixed

--- a/cmd/wrestic/args/args.go
+++ b/cmd/wrestic/args/args.go
@@ -1,0 +1,22 @@
+package args
+
+import "strings"
+
+type ArrayOpts []string
+
+func (a *ArrayOpts) String() string {
+	return strings.Join(*a, ", ")
+}
+
+func (a *ArrayOpts) BuildArgs() []string {
+	argList := []string{}
+	for _, elem := range *a {
+		argList = append(argList, "--tag", elem)
+	}
+	return argList
+}
+
+func (a *ArrayOpts) Set(value string) error {
+	*a = append(*a, value)
+	return nil
+}

--- a/restic/listsnapshots.go
+++ b/restic/listsnapshots.go
@@ -25,11 +25,12 @@ func newListSnapshots(commandState *commandState) *ListSnapshotsStruct {
 }
 
 // ListSnapshots executes the list snapshots command of restic.
-func (l *ListSnapshotsStruct) ListSnapshots(last bool) []Snapshot {
+func (l *ListSnapshotsStruct) ListSnapshots(last bool, tags []string) []Snapshot {
 	args := []string{"snapshots", "--json", "-q", "--no-lock"}
 	if last {
 		args = append(args, "--last")
 	}
+	args = append(args, tags...)
 
 	l.genericCommand.exec(args, commandOptions{print: false})
 	fmt.Printf("Listing snapshots\n")

--- a/restic/prune.go
+++ b/restic/prune.go
@@ -24,7 +24,7 @@ func newPrune(snapshotLister *ListSnapshotsStruct, webhookSender WebhookSender, 
 	}
 }
 
-func (p *PruneStruct) Prune() {
+func (p *PruneStruct) Prune(tags []string) {
 
 	// TODO: check for integers
 	args := []string{"forget", "--prune"}
@@ -53,6 +53,14 @@ func (p *PruneStruct) Prune() {
 		args = append(args, keepYearlyArg, yearly)
 	}
 
+	if keepTags := os.Getenv(keepTagsEnv); keepTags != "" {
+		for _, tag := range strings.Split(keepTags, ",") {
+			args = append(args, keepTagsArg, tag)
+		}
+	}
+
+	args = append(args, tags...)
+
 	fmt.Println("Run forget and update the webhook")
 	fmt.Println("forget params: ", strings.Join(args, " "))
 	p.genericCommand.exec(args, commandOptions{print: true})
@@ -65,7 +73,7 @@ func (p *PruneStruct) GetWebhookData() []output.JsonMarshaller {
 	stats = append(stats, &WebhookStats{
 		Name:       os.Getenv(Hostname),
 		BucketName: getBucket(),
-		Snapshots:  p.snapshotLister.ListSnapshots(false),
+		Snapshots:  p.snapshotLister.ListSnapshots(false, []string{}),
 	})
 
 	return stats

--- a/restic/restic.go
+++ b/restic/restic.go
@@ -25,7 +25,7 @@ const (
 	keepWeeklyEnv     = "KEEP_WEEKLY"
 	keepMonthlyEnv    = "KEEP_MONTHLY"
 	keepYearlyEnv     = "KEEP_YEARLY"
-	keepTagEnv        = "KEEP_TAG"
+	keepTagsEnv       = "KEEP_TAGS"
 	promURLEnv        = "PROM_URL"
 	statsURLEnv       = "STATS_URL"
 	BackupDirEnv      = "BACKUP_DIR"
@@ -40,6 +40,7 @@ const (
 	keepWeeklyArg  = "--keep-weekly"
 	keepMonthlyArg = "--keep-monthly"
 	keepYearlyArg  = "--keep-yearly"
+	keepTagsArg    = "--keep-tag"
 	//Restore
 	RestoreS3EndpointEnv     = "RESTORE_S3ENDPOINT"
 	RestoreS3AccessKeyIDEnv  = "RESTORE_ACCESSKEYID"

--- a/restic/restore.go
+++ b/restic/restore.go
@@ -180,7 +180,7 @@ func (r *RestoreStruct) folderRestore(snapshot Snapshot, tags []string) error {
 
 	r.genericCommand.exec(args, commandOptions{print: true})
 	notIgnoredErrors := 0
-	for _, errLine := range r.stdErrOut {
+	for _, errLine := range r.GetStdErrOut() {
 		if !strings.Contains(errLine, "Lchown") {
 			notIgnoredErrors++
 		}

--- a/restic/restore.go
+++ b/restic/restore.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"git.vshn.net/vshn/wrestic/cmd/wrestic/args"
 	"git.vshn.net/vshn/wrestic/output"
 	"git.vshn.net/vshn/wrestic/s3"
 )
@@ -58,7 +59,7 @@ func (r *RestoreStruct) setState(restoreType, restoreDir, restoreFilter string, 
 }
 
 // Archive uploads the last version of each snapshot to S3.
-func (r *RestoreStruct) Archive(snaps []Snapshot, restoreType, restoreDir, restoreFilter string, verifyRestore bool) {
+func (r *RestoreStruct) Archive(snaps []Snapshot, restoreType, restoreDir, restoreFilter string, verifyRestore bool, tags args.ArrayOpts) {
 
 	r.setState(restoreType, restoreDir, restoreFilter, verifyRestore)
 
@@ -67,7 +68,7 @@ func (r *RestoreStruct) Archive(snaps []Snapshot, restoreType, restoreDir, resto
 	for _, v := range snaps {
 		PVCname := r.parsePath(v.Paths)
 		fmt.Printf("Archive running for %v\n", fmt.Sprintf("%v-%v", v.Hostname, PVCname))
-		if err := r.restoreCommand(v.ID, r.restoreType, snaps); err != nil {
+		if err := r.restoreCommand(v.ID, r.restoreType, snaps, tags); err != nil {
 			r.errorMessage = err
 			return
 		}
@@ -95,20 +96,24 @@ func (r *restoreStats) ToJson() []byte {
 }
 
 // Restore takes a snapshotID and a method to create a restore job.
-func (r *RestoreStruct) Restore(snapshotID, method string, snaps []Snapshot, restoreDir, restoreFilter string, verifyRestore bool) {
+func (r *RestoreStruct) Restore(snapshotID, method string, snaps []Snapshot, restoreDir, restoreFilter string, verifyRestore bool, tags args.ArrayOpts) {
 
 	r.setState(method, restoreDir, restoreFilter, verifyRestore)
 
-	r.errorMessage = r.restoreCommand(snapshotID, method, snaps)
+	r.errorMessage = r.restoreCommand(snapshotID, method, snaps, tags)
 }
 
-func (r *RestoreStruct) restoreCommand(snapshotID, method string, snaps []Snapshot) error {
+func (r *RestoreStruct) restoreCommand(snapshotID, method string, snaps []Snapshot, tags args.ArrayOpts) error {
 	fmt.Println("Starting restore...")
 
 	snapshot := Snapshot{}
 
 	if snapshotID == "" {
-		fmt.Println("No snapshot defined, using latest one.")
+		if len(tags) > 0 {
+			fmt.Printf("Restoring latest snapshot with tags: %s\n", tags.String())
+		} else {
+			fmt.Println("No snapshot defined, using latest one.")
+		}
 		snapshot = snaps[len(snaps)-1]
 		fmt.Printf("Snapshot %v is being restored.\n", snapshot.Time)
 	} else {
@@ -130,17 +135,17 @@ func (r *RestoreStruct) restoreCommand(snapshotID, method string, snaps []Snapsh
 
 	// TODO: implement some enum here: https://blog.learngoprogramming.com/golang-const-type-enums-iota-bc4befd096d3
 	if method == "folder" {
-		return r.folderRestore(snapshot)
+		return r.folderRestore(snapshot, tags)
 	}
 
 	if method == "s3" {
-		return r.s3Restore(snapshot)
+		return r.s3Restore(snapshot, tags)
 	}
 
 	return fmt.Errorf("%v is not a valid restore type", r.restoreType)
 }
 
-func (r *RestoreStruct) folderRestore(snapshot Snapshot) error {
+func (r *RestoreStruct) folderRestore(snapshot Snapshot, tags []string) error {
 
 	var linkedDir string
 	var trim bool
@@ -162,6 +167,8 @@ func (r *RestoreStruct) folderRestore(snapshot Snapshot) error {
 	}
 
 	args := []string{"restore", snapshot.ID, "--target", linkedDir}
+
+	args = append(args, tags...)
 
 	if r.restoreFilter != "" {
 		args = append(args, "--include", r.restoreFilter)
@@ -214,7 +221,7 @@ func (r *RestoreStruct) linkRestorePaths(snapshot Snapshot) (string, error) {
 	return restoreRoot, nil
 }
 
-func (r *RestoreStruct) s3Restore(snapshot Snapshot) error {
+func (r *RestoreStruct) s3Restore(snapshot Snapshot, tags []string) error {
 	fmt.Println("S3 chosen as restore destination")
 
 	endpoint := os.Getenv(RestoreS3EndpointEnv)


### PR DESCRIPTION
With this commit it is possible to pass "--tag" multiple times to
wrestic to use restic's tagging functionality for backups and restores.

The tags are also included in the webhooks sent after the backup is
done.