### PR TITLE
Only wait for locks if it's an exclusive job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Make waiting for locks more stable
+
 ## [v0.2.0] 2020-05-29
 ### Changed
 - Complete rewrite of whole wrestic

--- a/cmd/wrestic/main.go
+++ b/cmd/wrestic/main.go
@@ -89,9 +89,11 @@ func run(resticCLI *restic.Restic, mainLogger logr.Logger) error {
 		os.Exit(1)
 	}
 
-	if err := resticCLI.Wait(); err != nil {
-		mainLogger.Error(err, "failed to list repository locks")
-		return err
+	if *prune || *check {
+		if err := resticCLI.Wait(); err != nil {
+			mainLogger.Error(err, "failed to list repository locks")
+			return err
+		}
 	}
 
 	commandRun := false


### PR DESCRIPTION
Also the wait will now only check for the existence of any locks, as
inspecting a lock will also create a lock, which in turn can lead to
some race conditions.