### PR TITLE
Fix/ignore stdin progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Make waiting for locks more stable
 - Don't drop k8sExe stderr output ([#27])
-
+- Don't print the percentage when using stdin backups ([#28])
 
 ## [v0.2.0] 2020-05-29
 ### Changed
@@ -142,3 +142,4 @@ compatibility with older operator versions. Changes to the design contain:
 [v0.0.1]: https://git.vshn.net/vshn/wrestic/tree/v0.0.1
 
 [#27]: https://github.com/vshn/wrestic/pull/27
+[#28]: https://github.com/vshn/wrestic/pull/28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Make waiting for locks more stable
 - Don't drop k8sExe stderr output ([#27])
 
+
 ## [v0.2.0] 2020-05-29
 ### Changed
 - Complete rewrite of whole wrestic

--- a/restic/stdinbackup.go
+++ b/restic/stdinbackup.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/vshn/wrestic/kubernetes"
+	"github.com/vshn/wrestic/logging"
 )
 
 // StdinBackup create a snapshot with the data contained in the given reader.
@@ -14,7 +15,7 @@ func (r *Restic) StdinBackup(data *kubernetes.ExecData, filename, fileExt string
 
 	stdinlogger.Info("starting stdin backup", "filename", filename, "extension", fileExt)
 
-	outputWriter := r.newParseBackupOutput(stdinlogger, filename+fileExt)
+	outputWriter := logging.NewStdinBackupOutputParser(stdinlogger.WithName("progress"), filename+fileExt, r.sendBackupStats)
 
 	opts := CommandOptions{
 		Path: r.resticPath,


### PR DESCRIPTION
This change will stop printing unnecessary percentage information for stdin backups.

It's already using the changes made in #27 cause the logging was refactored quite a bit. So #27 should be merged first.

Closes: #26