### PR TITLE
Update Restic  to 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Make waiting for locks more stable
 - Don't drop k8sExe stderr output ([#27])
 - Don't print the percentage when using stdin backups ([#28])
+### Changed
+- Update to Restic 0.12.0 ([#57])
 
 ## [v0.2.0] 2020-05-29
 ### Changed
@@ -143,3 +145,4 @@ compatibility with older operator versions. Changes to the design contain:
 
 [#27]: https://github.com/vshn/wrestic/pull/27
 [#28]: https://github.com/vshn/wrestic/pull/28
+[#57]: https://github.com/vshn/wrestic/pull/57


### PR DESCRIPTION
Restic 0.12.0 was recently released.

This PR will update the Wrestic image to use that version and remove our own patches, as they've been merged upstream.

Relates to: https://github.com/vshn/k8up/issues/356