### PR TITLE
Adjust exit code handling to 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Don't print the percentage when using stdin backups ([#28])
 ### Changed
 - Update to Restic 0.12.0 ([#57])
+- Adjust exit code handling to restic v0.12.0
 
 ## [v0.2.0] 2020-05-29
 ### Changed

--- a/cmd/wrestic/integration_test.go
+++ b/cmd/wrestic/integration_test.go
@@ -242,7 +242,7 @@ func TestInitRepoFail(t *testing.T) {
 
 	err := run(env.resticCli, env.log)
 
-	if err == nil || !strings.Contains(err.Error(), "exit status 1") {
+	if err == nil || !strings.Contains(err.Error(), "cmd.Wait() err: 1") {
 		t.Errorf("command did not fail with expected error, received error was: %v", err)
 	}
 


### PR DESCRIPTION
See https://restic.readthedocs.io/en/stable/040_backup.html?highlight=exit%20codes#exit-status-codes for more info.

Also some further optimizations were made like error wrapping.