### PR TITLE
Replace legacy env var assignment

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -16,10 +16,10 @@ jobs:
     - uses: actions/checkout@v1
     - name: Set version latest
       if: github.ref == 'refs/heads/master'
-      run: echo VERSION::latest >> $GITHUB_ENV
+      run: echo VERSION=latest >> $GITHUB_ENV
     - name: Set version from tag
       if: startsWith(github.ref, 'refs/tags/v')
-      run: echo VERSION::$(echo ${GITHUB_REF#refs/tags/}) >> $GITHUB_ENV
+      run: echo VERSION=$(echo ${GITHUB_REF#refs/tags/}) >> $GITHUB_ENV
     - name: Build Image
       run: docker build -t "${IMAGE}:${VERSION}" .
     - name: Push Image


### PR DESCRIPTION
With the new env var assignment we need to use `=` instead of `::`.