### PR TITLE
Fix restic binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Fixed
+- Wrong binary permissions in container ([#70])
 ## [v0.2.1] 2021-03-04
 ### Fixed
 - Make waiting for locks more stable
@@ -150,3 +151,4 @@ compatibility with older operator versions. Changes to the design contain:
 [#27]: https://github.com/vshn/wrestic/pull/27
 [#28]: https://github.com/vshn/wrestic/pull/28
 [#57]: https://github.com/vshn/wrestic/pull/57
+[#70]: https://github.com/vshn/wrestic/issues/70

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ RUN set -x; \
  && wget "https://github.com/restic/restic/releases/download/v${RESTIC_VERSION}/restic_${RESTIC_VERSION}_linux_amd64.bz2" \
  && bunzip2 "restic_${RESTIC_VERSION}_linux_amd64.bz2" \
  && mkdir /build \
- && mv "restic_${RESTIC_VERSION}_linux_amd64" /build/restic
+ && mv "restic_${RESTIC_VERSION}_linux_amd64" /build/restic \
+ && chmod +x /build/restic
 
 WORKDIR /app
 COPY go.mod go.sum ./

--- a/restic/command.go
+++ b/restic/command.go
@@ -88,6 +88,12 @@ func (c *Command) Wait() {
 		c.FatalError = fmt.Errorf("command not configured")
 		return
 	}
+
+	if c.cmd.Process == nil {
+		c.FatalError = fmt.Errorf("the process did not start, please check if execution bit is set")
+		return
+	}
+
 	err := c.cmd.Wait()
 	if err != nil {
 		// The error could contain an IO error...


### PR DESCRIPTION
Fixed the restic binary in the docker build, so it's executable.

As `cmd.Start()` doesn't seem to catch if the process actually started or not I also added if the process is nil and return an error.

closes #70