### PR TITLE
Make parsing restic output resilient to non-json output

### DIFF
--- a/restic/wait.go
+++ b/restic/wait.go
@@ -77,12 +77,11 @@ func (r *Restic) getLockList(log logr.Logger) ([]string, error) {
 	cmd := NewCommand(r.ctx, log, opts)
 	cmd.Run()
 
-	return []string(*list), cmd.FatalError
+	return *list, cmd.FatalError
 }
 
 type locklist []string
 
-func (l *locklist) out(s string) error {
+func (l *locklist) out(s string) {
 	*l = append(*l, s)
-	return nil
 }


### PR DESCRIPTION
This PR changes the parsing logic for parsing the restic output.
When some output can't be parsed as JSON, then it will still be written to the log, but it will not stop the processing of the output, as it did before.

As discussed in https://github.com/vshn/wrestic/issues/79#issuecomment-808104241