### PR TITLE
Reduce Restic Progress FPS

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -55,7 +55,6 @@ type PercentageFunc func(logr.InfoLogger, float64)
 type BackupOutputParser struct {
 	log            logr.Logger
 	errorCount     int
-	lineCounter    int
 	summaryFunc    SummaryFunc
 	percentageFunc PercentageFunc
 	folder         string
@@ -162,11 +161,7 @@ func (b *BackupOutputParser) out(s string) error {
 		b.errorCount++
 		b.log.Error(fmt.Errorf("error occurred during backup"), envelope.Item+" during "+envelope.During+" "+envelope.Error.Op)
 	case "status":
-		// Restic does the json output with 60hz, which is a bit much...
-		if b.lineCounter%60 == 0 {
-			b.percentageFunc(b.log, envelope.PercentDone)
-		}
-		b.lineCounter++
+		b.percentageFunc(b.log, envelope.PercentDone)
 	case "summary":
 		b.log.Info("backup finished", "new files", envelope.FilesNew, "changed files", envelope.FilesChanged, "errors", b.errorCount)
 		b.log.Info("stats", "time", envelope.TotalDuration, "bytes added", envelope.DataAdded, "bytes processed", envelope.TotalBytesProcessed)


### PR DESCRIPTION
By defining the environment variable [`RESTIC_PROGRESS_FPS` it is possible to reduce restic's output](https://restic.readthedocs.io/en/stable/manual_rest.html?highlight=frequency#usage-help).

The reason to introduce this change is that we suspect that the buffer of the scanner is eventually filling up. This PR does not fix that permanently, but it reduces the output of restic dramatically, which should at least should delay the occurence of such errors until a more permament is found.
Also, wrestic does not need the progress to be reported every 1/60th of a second.

The behavior now – as implemented – is that if `RESTIC_PROGRESS_FPS` is defined in the environment variables that are passed to `wrestic`, the given value will be used. Otherwise, `wrestic` will set the value to about one progress report line per minute (i.e. `1.0f/60.0f per Second`).

Originally discussed in https://github.com/vshn/wrestic/issues/79#issuecomment-808101342.