### PR TITLE
Improved logging when wrestic message is not JSON

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -147,7 +147,7 @@ func (b *BackupOutputParser) out(s string) {
 
 	err := json.Unmarshal([]byte(s), envelope)
 	if err != nil {
-		b.log.Info("wrestic output", "msg", s)
+		b.log.Info("restic output", "msg", s)
 	}
 
 	switch envelope.MessageType {


### PR DESCRIPTION
Outputs of wrestic, that are not JSON, are not errors any longer. This shall improve the user experience of human operators, when debugging wrestic backups.

Fixes https://github.com/vshn/wrestic/issues/85