### PR TITLE
Fix backing up of annotated pods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,9 @@ minio-download: .test/minio ## Download minio
 
 restic-download: .test/restic ## Download restic
 
+docker: ## Builds the docker image. Overwrite the tag by changing the 'docker_tag' variable.
+	@docker build -t $(docker_tag) .
+
 $(minio_pid): export MINIO_ACCESS_KEY = $(minio_root_user)
 $(minio_pid): export MINIO_SECRET_KEY = $(minio_root_password)
 $(minio_pid): minio-download

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -31,3 +31,5 @@ minio_root_user ?= accesskey
 minio_root_password ?= secretkey
 minio_pid ?= $(minio_path).pid
 minio_url ?= https://dl.min.io/server/minio/release/$(os)-$(arch)/minio
+
+docker_tag ?= vshn/wrestic:snapshot

--- a/cmd/wrestic/main.go
+++ b/cmd/wrestic/main.go
@@ -97,10 +97,10 @@ func run(resticCLI *restic.Restic, mainLogger logr.Logger) error {
 		}
 	}
 
-	commandRun := false
+	dontBackup := false
 
 	if *prune {
-		commandRun = true
+		dontBackup = true
 		if err := resticCLI.Prune(tags); err != nil {
 			mainLogger.Error(err, "prune job failed")
 			return err
@@ -108,7 +108,7 @@ func run(resticCLI *restic.Restic, mainLogger logr.Logger) error {
 	}
 
 	if *check {
-		commandRun = true
+		dontBackup = true
 		if err := resticCLI.Check(); err != nil {
 			mainLogger.Error(err, "check job failed")
 			return err
@@ -116,7 +116,7 @@ func run(resticCLI *restic.Restic, mainLogger logr.Logger) error {
 	}
 
 	if *restore {
-		commandRun = true
+		dontBackup = true
 		if err := resticCLI.Restore(*restoreSnap, restic.RestoreOptions{
 			RestoreType:   restic.RestoreType(*restoreType),
 			RestoreDir:    os.Getenv(restic.RestoreDirEnv),
@@ -134,59 +134,73 @@ func run(resticCLI *restic.Restic, mainLogger logr.Logger) error {
 	}
 
 	if *archive {
-		commandRun = true
+		dontBackup = true
 		if err := resticCLI.Archive(*restoreFilter, *verifyRestore, tags); err != nil {
 			mainLogger.Error(err, "archive job failed")
 			return err
 		}
 	}
 
-	if !commandRun {
-		commandAnnotation := os.Getenv(commandEnv)
-		if commandAnnotation == "" {
-			commandAnnotation = "k8up.syn.tools/backupcommand"
-		}
-		fileextAnnotation := os.Getenv(fileextEnv)
-		if fileextAnnotation == "" {
-			fileextAnnotation = "k8up.syn.tools/file-extension"
-		}
+	if dontBackup {
+		return nil
+	}
 
-		_, serviceErr := os.Stat("/var/run/secrets/kubernetes.io")
-		_, kubeconfigErr := os.Stat(kubernetes.Kubeconfig)
+	err := backupAnnotatedPods(resticCLI, mainLogger)
+	if err != nil {
+		mainLogger.Error(err, "backup job failed", "step", "backup of annotated pods")
+		return err
+	}
+	mainLogger.Info("backups of annotated jobs have finished successfully")
 
-		if serviceErr == nil && kubeconfigErr == nil {
+	err = resticCLI.Backup(getBackupDir(), tags)
+	if err != nil {
+		mainLogger.Error(err, "backup job failed", "step", "backup of dir failed", "dir", getBackupDir())
+		return err
+	}
 
-			podLister := kubernetes.NewPodLister(commandAnnotation, fileextAnnotation, os.Getenv(restic.Hostname), mainLogger)
+	return nil
+}
 
-			podList, err := podLister.ListPods()
+func backupAnnotatedPods(resticCLI *restic.Restic, mainLogger logr.Logger) error {
+	commandAnnotation := os.Getenv(commandEnv)
+	if commandAnnotation == "" {
+		commandAnnotation = "k8up.syn.tools/backupcommand"
+	}
+	fileextAnnotation := os.Getenv(fileextEnv)
+	if fileextAnnotation == "" {
+		fileextAnnotation = "k8up.syn.tools/file-extension"
+	}
 
-			if err == nil {
-				for _, pod := range podList {
-					data, err := kubernetes.PodExec(pod, mainLogger)
-					if err != nil {
-						mainLogger.Error(errors.New("error occured during data stream from k8s"), "pod execution was interrupted")
-						return err
-					}
-					filename := fmt.Sprintf("/%s-%s", os.Getenv(restic.Hostname), pod.ContainerName)
-					err = resticCLI.StdinBackup(data, filename, pod.FileExtension, tags)
-					if err != nil {
-						mainLogger.Error(err, "backup commands failed")
-						return err
-					}
-				}
-				mainLogger.Info("all pod commands have finished successfully")
-			} else {
-				mainLogger.Error(err, "could not list pods", "namespace", os.Getenv(restic.Hostname))
-			}
-		}
+	_, serviceErr := os.Stat("/var/run/secrets/kubernetes.io")
+	_, kubeconfigErr := os.Stat(kubernetes.Kubeconfig)
 
-		err := resticCLI.Backup(getBackupDir(), tags)
+	if serviceErr != nil && kubeconfigErr != nil {
+		mainLogger.Info("No kubernetes credentials configured: Can't check for annotated Pods.")
+		return nil
+	}
+
+	podLister := kubernetes.NewPodLister(commandAnnotation, fileextAnnotation, os.Getenv(restic.Hostname), mainLogger)
+	podList, err := podLister.ListPods()
+
+	if err != nil {
+		mainLogger.Error(err, "could not list pods", "namespace", os.Getenv(restic.Hostname))
+		return nil
+	}
+
+	for _, pod := range podList {
+		data, err := kubernetes.PodExec(pod, mainLogger)
 		if err != nil {
-			mainLogger.Error(err, "backup job failed")
+			mainLogger.Error(errors.New("error occurred during data stream from k8s"), "pod execution was interrupted")
 			return err
 		}
-
+		filename := fmt.Sprintf("/%s-%s", os.Getenv(restic.Hostname), pod.ContainerName)
+		err = resticCLI.StdinBackup(data, filename, pod.FileExtension, tags)
+		if err != nil {
+			mainLogger.Error(err, "backup commands failed")
+			return err
+		}
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
A recent modification inadvertently changed the behaviour of wrestic in a way, that it would no longer perform backups of annotated pods. This PR restores the functionality and refactores the code in a way that hopefully prevents such a missunderstanding in the future.

Fixes https://github.com/vshn/k8up/issues/436