### PR TITLE
Remove stale locks before invoking other restic actions

### DIFF
--- a/cmd/wrestic/main.go
+++ b/cmd/wrestic/main.go
@@ -83,6 +83,10 @@ func run(resticCLI *restic.Restic, mainLogger logr.Logger) error {
 		return err
 	}
 
+	if err := resticCLI.Unlock(false); err != nil {
+		mainLogger.Error(err, "failed to remove stale locks from the repository, continuing anyway")
+	}
+
 	// This builds up the cache without any other side effect. So it won't block
 	// during any stdin backups or such.
 	if err := resticCLI.Snapshots(nil); err != nil {

--- a/restic/unlock.go
+++ b/restic/unlock.go
@@ -3,14 +3,15 @@ package restic
 import "github.com/vshn/wrestic/logging"
 
 // Unlock will remove stale locks from the repository
+// If the all flag is set to true, even non-stale locks are removed.
 func (r *Restic) Unlock(all bool) error {
 	unlocklogger := r.logger.WithName("unlock")
 
 	unlocklogger.Info("unlocking repository", "all", all)
 
 	opts := CommandOptions{
-		Path: r.resticPath,
-		Args: r.globalFlags.ApplyToCommand("unlock"),
+		Path:   r.resticPath,
+		Args:   r.globalFlags.ApplyToCommand("unlock"),
 		StdOut: logging.NewErrorWriter(unlocklogger.WithName("restic")),
 		StdErr: logging.NewErrorWriter(unlocklogger.WithName("restic")),
 	}


### PR DESCRIPTION
Fixes https://github.com/vshn/k8up/issues/456, which reports that in certain cases restic locks are not properly removed. This change addresses this by invoking the `unlock` action before any other action. It removes stale locks on the repository.